### PR TITLE
'subsriber' typo fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,7 +302,7 @@ mere altruism or showcasing of ones' abilities.
 </p><p>
 The mere mention of money raises eyebrows.  My solution to aleviate concerns is
 to require a modest subscription fee to users who wish to utilize the platform, but
-to enable the subsriber to allocate 100% of their fee to the developer(s) of their choice.
+to enable the subscriber to allocate 100% of their fee to the developer(s) of their choice.
 </p><p>
 To remain copacetic with the principles of openness and software freedom,
 we encourage opensource licenses and app design which can be used stand-alone and


### PR DESCRIPTION
Simple typo fix.

I first saw this in the copypasta made to the IAEP list. 
-
Having it hosted this way makes it easy to submit the fix :-)